### PR TITLE
Find all chat export files

### DIFF
--- a/tasks/src/tasks/telegram.py
+++ b/tasks/src/tasks/telegram.py
@@ -1,20 +1,28 @@
 import os
+from typing import List
 
 
-def find_chat_export_dirs(path):
-    chat_export_dirs = []
+def is_messages_filename(filename: str) -> bool:
+    return filename.startswith("messages") and filename.endswith(".html")
+
+
+def find_messages_files(path: str) -> List[str]:
+    "Find all messages files in the given path"
+
+    messages_files: List[str] = []
+
     for root, dirs, files in os.walk(path):
-        for dir_name in dirs:
-            if dir_name.startswith("ChatExport_"):
-                relative_path = os.path.relpath(os.path.join(root, dir_name), path)
-                chat_export_dirs.append(relative_path)
-    return chat_export_dirs
+        messages_files.extend(
+            [os.path.join(root, f) for f in files if is_messages_filename(f)]
+        )
+
+    return messages_files
 
 
 def build(dataset_path, output_path):
-    chat_export_dirs = find_chat_export_dirs(dataset_path)
-    print(f"Found {len(chat_export_dirs)} chat export directories")
-    for chat_export_dir in chat_export_dirs:
-        print(f"Processing '{chat_export_dir}'")
+    chat_export_files = find_messages_files(dataset_path)
+    print(f"Found {len(chat_export_files)} chat export files")
+    for chat_export_file in chat_export_files:
+        print(f"Processing '{chat_export_file}'")
 
     # TODO: finish


### PR DESCRIPTION
Some chat export files are in directories that do not start with ChatExport, and some export directories have more than one messages file. Rather than search for directories starting with "ChatExport", this searches for all files matching "messages*.html", which seems to return all results.