### PR TITLE
Add option to store absolute or relative paths in the DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,6 @@ cython_debug/
 # ignore _ osx files
 ._*
 .DS_Store
+
+# Don't accidentally include generated DB files
+telegram_chats.db

--- a/tasks/src/tasks/__init__.py
+++ b/tasks/src/tasks/__init__.py
@@ -12,11 +12,17 @@ def cli():
 @cli.command()
 @click.argument("dataset_path")
 @click.argument("output_path")
-def build_telegram_db(dataset_path, output_path):
+@click.option(
+    "-a",
+    "--absolute-paths",
+    is_flag=True,
+    help="Store absolute file paths in the database. By default, relative paths are stored.",
+)
+def build_telegram_db(dataset_path, output_path, absolute_paths):
     """
     Build a SQLite3 database of Telegram chats
     """
-    telegram.build(dataset_path, output_path)
+    telegram.build(dataset_path, output_path, absolute_paths)
 
 
 if __name__ == "__main__":

--- a/tasks/src/tasks/telegram.py
+++ b/tasks/src/tasks/telegram.py
@@ -1,4 +1,5 @@
 import os
+import os.path
 import re
 from bs4 import BeautifulSoup, Tag
 from datetime import datetime, UTC, timezone, timedelta, tzinfo
@@ -309,7 +310,19 @@ def parse_messages_file(filename: str) -> MessagesFile:
     return messages_file
 
 
-def build(dataset_path: str, output_path: str) -> None:
+def messages_file_path_for_db(
+    store_abs: bool, dataset_path: str, messages_file_path: str
+) -> str:
+    abs_dataset_path = os.path.abspath(dataset_path)
+    abs_messages_file_path = os.path.abspath(messages_file_path)
+
+    if store_abs:
+        return abs_messages_file_path
+
+    return abs_messages_file_path.removeprefix(abs_dataset_path).removeprefix("/")
+
+
+def build(dataset_path: str, output_path: str, absolute_paths: bool) -> None:
     # Create the output directory if it doesn't exist
     os.makedirs(output_path, exist_ok=True)
 
@@ -333,8 +346,9 @@ def build(dataset_path: str, output_path: str) -> None:
 
         group_chat_id = insert_group_chats(cur, list(messages_file.chat_titles))
 
-        messages_file_path = chat_export_file.removeprefix(dataset_path)
-        messages_file_path = messages_file_path.removeprefix("/")
+        messages_file_path = messages_file_path_for_db(
+            absolute_paths, dataset_path, chat_export_file
+        )
 
         insert_messages(cur, group_chat_id, messages_file_path, messages_file.messages)
 

--- a/tasks/src/tasks/telegram_db.py
+++ b/tasks/src/tasks/telegram_db.py
@@ -1,3 +1,4 @@
+import os.path
 import sqlite3
 from typing import List
 
@@ -74,7 +75,11 @@ def insert_messages(
             message.sender,
             message.text,
             message.media_note,
-            message.media_filename,
+            (
+                os.path.join(filename, message.media_filename)
+                if message.media_filename
+                else None
+            ),
             filename,
             group_chat_id,
         )


### PR DESCRIPTION
References to the messages file or any media files in the DB will default to being relative to the dataset_path. This is the default because 1) it would be desired when distributing the DB and 2) it doesn't reveal any information that could be contained in the full path.

Passing `-a` or `--absolute-paths` will store absolute paths in the DB, which could be helpful if you're working with a copy of the DB that you generated locally.